### PR TITLE
fix: allow latest bus client version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ovos-plugin-manager>=0.0.21,<1.0.0
-ovos-bus-client>=0.0.3,<1.0.0
+ovos-bus-client>=0.0.3,<2.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version constraint for the `ovos-bus-client` dependency, expanding the range of acceptable versions to enhance compatibility and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->